### PR TITLE
chore: standardize repo with security policy, pre-commit, and release automation

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   pr-validation:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/pr_checks.yml@2.1.0
+    uses: clouddrove/github-shared-workflows/.github/workflows/pr-checks.yml@2.1.0
     secrets: inherit
     with:
       subjectPattern: '^.+$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,29 @@
 repos:
-
-  - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
     hooks:
-      - id: terraform-fmt
-      - id: shellcheck
-      - id: tflint
-
+      - id: terraform_fmt
+      - id: terraform_docs
+        args:
+          - '--args=--lockfile=false'
+      - id: terraform_tflint
+        args:
+          - '--args=--only=terraform_deprecated_interpolation'
+          - '--args=--only=terraform_deprecated_index'
+          - '--args=--only=terraform_unused_declarations'
+          - '--args=--only=terraform_comment_syntax'
+          - '--args=--only=terraform_documented_outputs'
+          - '--args=--only=terraform_documented_variables'
+          - '--args=--only=terraform_typed_variables'
+          - '--args=--only=terraform_module_pinned_source'
+          - '--args=--only=terraform_naming_convention'
+          - '--args=--only=terraform_required_version'
+          - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_standard_module_structure'
+      - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0 # Use the ref you want to point at
+    rev: v5.0.0
     hooks:
+      - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: mixed-line-ending
-      - id: check-byte-order-marker
-      - id: check-executables-have-shebangs
-      - id: check-merge-conflict
-      - id: debug-statements
-      - id: check-yaml
-      - id: check-added-large-files

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,14 @@
+{
+  "branches": ["main", "master"],
+  "ci": false,
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {"preset": "conventionalcommits"}],
+    ["@semantic-release/release-notes-generator", {"preset": "conventionalcommits"}],
+    ["@semantic-release/github", {
+      "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version}",
+      "labels": false
+    }],
+    ["@semantic-release/changelog", {"changelogFile": "CHANGELOG.md"}],
+    ["@semantic-release/git", {"assets": ["CHANGELOG.md"], "message": "chore(release): version ${nextRelease.version} [skip ci]"}]
+  ]
+}


### PR DESCRIPTION
## Summary
- Add SECURITY.md with vulnerability reporting policy
- Add CONTRIBUTING.md with development guidelines
- Add .releaserc.json for semantic-release automation
- Update .editorconfig to match industry standards
- Update .pre-commit-config.yaml to antonbabenko/pre-commit-terraform v1.105.0
- Set provider: none in tf-checks workflow (skip cloud auth for validate-only)
- Fix version constraints if needed

## Test plan
- [ ] Verify pre-commit hooks pass locally
- [ ] Verify CI checks pass
- [ ] Verify terraform validate succeeds